### PR TITLE
Add interface structure

### DIFF
--- a/experiments/SoilModel/coupled_equilibrium.jl
+++ b/experiments/SoilModel/coupled_equilibrium.jl
@@ -1,12 +1,7 @@
-import ClimaCore.Geometry, LinearAlgebra, UnPack
 import ClimaCore:
     Fields,
     Domains,
-    Topologies,
     Meshes,
-    DataLayouts,
-    Operators,
-    Geometry,
     Spaces
 
 using CLIMAParameters
@@ -14,100 +9,21 @@ using CLIMAParameters.Planet: ρ_cloud_liq, ρ_cloud_ice, cp_l, cp_i, T_0, LH_f0
 struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 
-using RecursiveArrayTools
 using OrdinaryDiffEq:
     ODEProblem,
     solve,
-    SSPRK33,
-    Rosenbrock23,
-    Tsit5,
-    SSPRK432,
-    Feagin14,
     TsitPap8,
     CarpenterKennedy2N54
-using DifferentialEquations
 using Plots
-using DelimitedFiles
 using UnPack
 using LandHydrology
-using LandHydrology.SoilHeatParameterizations
-using LandHydrology.SoilWaterParameterizations
-using Test
-using Statistics
+using LandHydrology.SoilInterface
+using LandHydrology.SoilInterface.SoilHeatParameterizations
+using LandHydrology.SoilInterface.SoilWaterParameterizations
 
 const FT = Float64
 
-abstract type BC{FT <: AbstractFloat} end
-
-struct FluxBC{FT} <: BC{FT}
-    top_heat_flux::FT
-    top_water_flux::FT
-    btm_heat_flux::FT
-    btm_water_flux::FT
-end
-
-
-function compute_integrated_rhs!(dY, Y, t, p)
-
-    sp = p[1]
-    param_set = p[2]
-    zc = p[3]
-    @unpack top_heat_flux, btm_heat_flux, top_water_flux, btm_water_flux = p[4]
-    @unpack ν, vgn, vgα, vgm, ksat, θr, ρc_ds, κ_sat_unfrozen, κ_sat_frozen = sp
-    ϑ_l = Y.x[1]
-    θ_i = Y.x[2]
-    ρe_int = Y.x[3]
-
-    dϑ_l = dY.x[1]
-    dθ_i = dY.x[2]
-    dρe_int = dY.x[3]
-
-    # Compute center values of everything
-    θ_l = ϑ_l
-    ρc_s = volumetric_heat_capacity.(θ_l, θ_i, ρc_ds, Ref(param_set))
-    T = temperature_from_ρe_int.(ρe_int, θ_i, ρc_s, Ref(param_set))
-    κ_dry = k_dry(param_set, sp)
-    S_r = relative_saturation.(θ_l, θ_i, ν)
-    kersten = kersten_number.(θ_i, S_r, Ref(sp))
-    κ_sat =
-        saturated_thermal_conductivity.(θ_l, θ_i, κ_sat_unfrozen, κ_sat_frozen)
-    κ = thermal_conductivity.(κ_dry, kersten, κ_sat)
-    ρe_int_l = volumetric_internal_energy_liq.(T, Ref(param_set))
-
-    cs = axes(θ_i)
-
-
-    S = effective_saturation.(θ_l; ν = ν, θr = θr)
-    K = hydraulic_conductivity.(S; vgm = vgm, ksat = ksat)
-    ψ = matric_potential.(S; vgn = vgn, vgα = vgα, vgm = vgm)
-    h = ψ .+ zc
-
-    interpc2f = Operators.InterpolateC2F()
-    gradc2f_heat = Operators.GradientC2F()
-    gradf2c_heat = Operators.GradientF2C(
-        top = Operators.SetValue(top_heat_flux),
-        bottom = Operators.SetValue(btm_heat_flux),
-    )
-
-    gradc2f_water = Operators.GradientC2F()
-    gradf2c_water = Operators.GradientF2C(
-        top = Operators.SetValue(top_water_flux),
-        bottom = Operators.SetValue(btm_water_flux),
-    )
-
-    @. dϑ_l = -gradf2c_water(-interpc2f(K) * gradc2f_water(h)) #Richards equation
-    @. dρe_int =
-        -gradf2c_heat(
-            -interpc2f(κ) * gradc2f_heat(T) -
-            interpc2f(ρe_int_l * K) * gradc2f_water(h),
-        )
-    dθ_i = Fields.zeros(eltype(θ_i), cs)
-
-    return dY
-
-end
-
-# General composition
+# General soil composition
 ν = FT(0.395);
 ν_ss_quartz = FT(0.92)
 ν_ss_minerals = FT(0.08)
@@ -180,41 +96,62 @@ top_water_flux = FT(0)
 top_heat_flux = FT(0)
 bottom_water_flux = FT(0)
 bottom_heat_flux = FT(0)
-bc = FluxBC(top_heat_flux, top_water_flux, bottom_heat_flux, bottom_water_flux)
-
-#Parameter structure
-p = [msp, param_set, zc, bc]
-
-#initial conditions
-T_max = FT(289.0)
-T_min = FT(288.0)
-c = FT(20.0)
-T = @. T_min + (T_max - T_min) * exp(-(zc - zmax) / (zmin - zmax) * c)
-
-θ_i = Fields.zeros(FT, cs)
-
-theta_max = FT(ν * 0.5)
-theta_min = FT(ν * 0.4)
-θ_l = @. theta_min +
-   (theta_max - theta_min) * exp(-(zc - zmax) / (zmin - zmax) * c)
+bc = SoilDomainBC(top = SoilComponentBC(hydrology = VerticalFlux(top_water_flux),
+                                        energy = VerticalFlux(top_heat_flux)),
+                  bottom = SoilComponentBC(hydrology = VerticalFlux(bottom_water_flux),
+                                           energy = VerticalFlux(bottom_heat_flux)))
 
 
-ρc_s = volumetric_heat_capacity.(θ_l, θ_i, ρc_ds, Ref(param_set))
-ρe_int = volumetric_internal_energy.(θ_i, ρc_s, T, Ref(param_set))
+# create model
+soil_model = SoilModel(SoilEnergyModel(), SoilHydrologyModel(), bc, msp, param_set)
 
-Y = ArrayPartition(θ_l, θ_i, ρe_int)
+# initial conditions
 
-function ∑tendencies!(dY, Y, p, t)
-    #intermediate step to be added if needed
-    compute_integrated_rhs!(dY, Y, t, p)
+function energy_ic(z, model)
+    soil_param_set = model.soil_param_set
+    earth_param_set = model.earth_param_set
+    c = 20.0
+    zmin = -1.0
+    zmax = 0.0
+    θ_max = 0.1975
+    θ_min = 0.158
+    θ_i = 0.0
+    θ_l  = θ_min +
+        (θ_max - θ_min) * exp(-(z - zmax) / (zmin - zmax) * c)
+    T = 288.0 + (289.0 - 288.0) * exp(-(z - zmax) / (zmin - zmax) * c)
+    ρc_ds = soil_param_set.ρc_ds
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, earth_param_set)
+    ρe_int = volumetric_internal_energy(θ_i, ρc_s, T, earth_param_set)
+    return (;ρe_int = ρe_int,)
 end
 
-prob = ODEProblem(∑tendencies!, Y, (t0, tf), p)
+
+function hydrology_ic(z, model)
+    θ_max = 0.1975
+    θ_min = 0.158
+    c = 20.0
+    zmin = -1.0
+    zmax = 0.0
+    
+    θ_i = 0.0
+    θ_l  = θ_min +
+        (θ_max - θ_min) * exp(-(z - zmax) / (zmin - zmax) * c)
+    return (ϑ_l = θ_l, θ_i = θ_i)
+end
+
+ic = SoilIC(; hydrology = hydrology_ic, energy = energy_ic)
+
+Y = create_initial_state(soil_model, ic, zc)
+soil_rhs! = make_rhs(soil_model)
+dY =  similar(Y)
+soil_rhs!(dY,Y,[],0.0)
+prob = ODEProblem(soil_rhs!, Y, (t0, tf), [])
 
 # solve simulation
 sol = solve(
     prob,
-    TsitPap8(),
+    #TsitPap8(), doesnt work, ArgumentError: broadcasting over dictionaries and `NamedTuple`s is reserved
+    CarpenterKennedy2N54(), # this does work
     dt = dt,
     saveat = 60 * dt,
     progress = true,
@@ -222,128 +159,30 @@ sol = solve(
 );
 
 
-
-
-#### for the sequential coupler
-#=
-integrator = init(prob, CarpenterKennedy2N54(),dt= dt)
-N = Int((tf-t0)/dt)
-for n in 1:1:N
-    step!(integrator,dt,true) # integrates to t+dt exactly
-    integrator.p[4].top_heat_flux = new_value # coupler could reset heat flux (to be a constant over soil time step, such that Fdt = accumulated atmos flux
-    
-end
-=#
-
-#alternatively, can do with callback
-#=
-function condition(u,t,integrator) # Event at every time step?
-    t = integrator.t_prev+dt ## should access dt in integrator?
-end
-function affect!(integrator)
-    integrator.p[4].top_heat_flux= new_top_heat_flux_value
-end
-cb = ContinuousCallback(condition, affect!)
-integrator = init(prob, CarpenterKennedy2N54(),dt= dt, callback= cb)
-#etc.
-
-
-=#
-
-
 #Plotting
-#=
+z = parent(zc)
+ϑ_l = [parent(sol.u[k].x[1].ϑ_l) for k in 1:length(sol.u)]
+θ_i = [parent(sol.u[k].x[1].θ_i) for k in 1:length(sol.u)]
+ρe_int = [parent(sol.u[k].x[2].ρe_int) for k in 1:length(sol.u)]
+indices = [1, 36, 72, 108, length(sol.t)]
+labels = ["IC", "18h", "36h", "54h", "72h"]
 plot1 = plot(
-    parent(sol.u[1].x[1]),parent(zc),
-    xlim = (0, ν),
+    xlim = (0.1, 0.25),
     ylim = (-1, 0),
-    label = "IC",
-    lc = :black,
-    lw = 2,
     legend = :outerright,
     xlabel = "θ(z)",
     ylabel = "z",
 )
-plot!(
-    parent(sol.u[36].x[1]),parent(zc),
-    label = "18h",
-    lc = :red,
-    lw = 2,
- 
-)
-plot!(
-    parent(sol.u[72].x[1]),parent(zc),
-    label = "36h",
-    lc = :blue,
-    lw = 2,
- 
-)
-plot!(
-    parent(sol.u[108].x[1]),parent(zc),
-    label = "54h",
-    lc = :orange,
-    lw = 2,
- 
-)
+for i in 1:1:length(indices)
+    plot!(ϑ_l[indices[i]], z, label = labels[i], lw = 2)
+end
+plot2 =
+    plot(ylim = (-1, 0), legend = :outerright, xlabel = "T(K)", ylabel = "z")
+for i in 1:1:length(indices)
+    k = indices[i]
+    ρc_s = volumetric_heat_capacity.(ϑ_l[k], θ_i[k], ρc_ds, Ref(param_set))
+    temp = temperature_from_ρe_int.(ρe_int[k], θ_i[k], ρc_s, Ref(param_set))
+    plot!(temp, z, label = labels[i], lw = 2)
+end
 
-plot!(
-    parent(sol.u[end].x[1]),parent(zc),
-    label = "72h",
-    lc = :green,
-    lw = 2,
- 
-)
-
-
-ρc_s = volumetric_heat_capacity.(sol.u[1].x[1], sol.u[1].x[2], ρc_ds, Ref(param_set))
-temp = temperature_from_ρe_int.(sol.u[1].x[3], sol.u[1].x[2], ρc_s, Ref(param_set))
-plot2 = plot(
-    parent(temp),parent(zc),
-   # xlim = (0, ν),
-    ylim = (-1, 0),
-    label = "IC",
-    lc = :black,
-    lw = 2,
-    legend = :outerright,
-    xlabel = "T(K)",
-    ylabel = "z",
-)
-ρc_s = volumetric_heat_capacity.(sol.u[36].x[1], sol.u[36].x[2], ρc_ds, Ref(param_set))
-temp = temperature_from_ρe_int.(sol.u[36].x[3], sol.u[36].x[2], ρc_s, Ref(param_set))
-plot!(
-    parent(temp),parent(zc),
-    label = "18h",
-    lc = :red,
-    lw = 2,
- 
-)
-ρc_s = volumetric_heat_capacity.(sol.u[72].x[1], sol.u[72].x[2], ρc_ds, Ref(param_set))
-temp = temperature_from_ρe_int.(sol.u[72].x[3], sol.u[72].x[2], ρc_s, Ref(param_set))
-plot!(
-    parent(temp),parent(zc),
-    label = "36h",
-    lc = :blue,
-    lw = 2,
- 
-)
-ρc_s = volumetric_heat_capacity.(sol.u[108].x[1], sol.u[108].x[2], ρc_ds, Ref(param_set))
-temp = temperature_from_ρe_int.(sol.u[108].x[3], sol.u[108].x[2], ρc_s, Ref(param_set))
-plot!(
-    parent(temp),parent(zc),
-    label = "54h",
-    lc = :orange,
-    lw = 2,
- 
-)
-ρc_s = volumetric_heat_capacity.(sol.u[end].x[1], sol.u[end].x[2], ρc_ds, Ref(param_set))
-temp = temperature_from_ρe_int.(sol.u[end].x[3], sol.u[end].x[2], ρc_s, Ref(param_set))
-plot!(
-    parent(temp),parent(zc),
-    label = "72h",
-    lc = :green,
-    lw = 2,
- 
-)
-
-plot(plot1,plot2)
-=#
+plot(plot1, plot2)

--- a/src/LandHydrology.jl
+++ b/src/LandHydrology.jl
@@ -1,58 +1,5 @@
 module LandHydrology
-export SoilParams, SoilWaterParams, SoilHeatParams
-
-abstract type ParameterStructure{FT <: AbstractFloat} end
-
-struct SoilParams{FT} <: ParameterStructure{FT}
-    ν::FT
-    vgn::FT
-    vgα::FT
-    vgm::FT
-    ksat::FT
-    θr::FT
-    S_s::FT
-    ν_ss_gravel::FT
-    ν_ss_om::FT
-    ν_ss_quartz::FT
-    ρc_ds::FT
-    κ_solid::FT
-    ρp::FT
-    κ_sat_unfrozen::FT
-    κ_sat_frozen::FT
-    a::FT
-    b::FT
-    κ_dry_parameter::FT
-end
-
-struct SoilWaterParams{FT} <: ParameterStructure{FT}
-    ν::FT
-    vgn::FT
-    vgα::FT
-    vgm::FT
-    ksat::FT
-    θr::FT
-    S_s::FT
-end
-
-
-struct SoilHeatParams{FT} <: ParameterStructure{FT}
-    ν::FT
-    ν_ss_gravel::FT
-    ν_ss_om::FT
-    ν_ss_quartz::FT
-    ρc_ds::FT
-    κ_solid::FT
-    ρp::FT
-    κ_sat_unfrozen::FT
-    κ_sat_frozen::FT
-    a::FT
-    b::FT
-    κ_dry_parameter::FT
-end
-
 
 include(joinpath("SoilModel", "SoilInterface.jl"))
-include(joinpath("SoilModel", "SoilWaterParameterizations.jl"))
-include(joinpath("SoilModel", "SoilHeatParameterizations.jl"))
 
 end # module

--- a/src/SoilModel/SoilInterface.jl
+++ b/src/SoilModel/SoilInterface.jl
@@ -1,0 +1,15 @@
+module SoilInterface
+import ClimaCore:    Fields, Operators, Geometry
+using DocStringExtensions
+using UnPack
+
+include("SoilWaterParameterizations.jl")
+using .SoilWaterParameterizations
+include("SoilHeatParameterizations.jl")
+using .SoilHeatParameterizations
+
+include("parameters.jl")
+include("models.jl")
+include("initial_conditions.jl")
+
+end

--- a/src/SoilModel/boundary_conditions.jl
+++ b/src/SoilModel/boundary_conditions.jl
@@ -1,0 +1,41 @@
+export VerticalFlux,SoilDomainBC, SoilComponentBC, NoBC, compute_vertical_flux
+abstract type AbstractBC end
+
+struct NoBC <: AbstractBC end
+
+struct VerticalFlux{f <: AbstractFloat} <: AbstractBC
+    "Scalar flux; positive = aligned with ẑ"
+    vertical_flux::f
+end
+
+struct FreeDrainage <: AbstractBC
+end
+
+Base.@kwdef struct SoilDomainBC{TBC, BBC}
+    top::TBC = SoilComponentBC()
+    bottom::BBC = SoilComponentBC()
+end
+
+Base.@kwdef struct SoilComponentBC{ebc<: AbstractBC, hbc<:AbstractBC}
+    energy::ebc = NoBC()
+    hydrology::hbc = NoBC()
+end
+
+
+function compute_vertical_flux(bc::VerticalFlux, _...)
+    return Geometry.Cartesian3Vector(bc.vertical_flux)
+end
+#unclear if we need this
+function compute_vertical_flux(bc::NoBC, _...)
+    return nothing
+end
+
+function compute_vertical_flux(bc::FreeDrainage, Y)# this only make sense to use at the bottom, but the user should know this. 
+    (Y_hydro, Y_energy) = Y.x
+    @unpack ϑ_l, θ_i = Y_hydro
+    θ_l = ϑ_l
+    S = effective_saturation.(θ_l; ν = ν, θr = θr)
+    K = hydraulic_conductivity.(S; vgm = vgm, ksat = ksat)
+    flux = -parent(K)[1] # = -K∇h when ∇h = 1. ∇h = 1 -> θ_c = θ_f at the bottom, so use K(θ_c).
+    return Geometry.Cartesian3Vector(flux)
+end

--- a/src/SoilModel/initial_conditions.jl
+++ b/src/SoilModel/initial_conditions.jl
@@ -1,0 +1,19 @@
+export SoilIC, create_initial_state
+using RecursiveArrayTools: ArrayPartition
+abstract type AbstractModelIC end
+
+struct SoilIC{H,E} <: AbstractModelIC
+    hydrology::H
+    energy::E
+end
+
+function SoilIC(;energy = energy, hydrology = hydrology)
+    args = (hydrology, energy)
+    return SoilIC{typeof.(args)...}(args...)
+end
+
+function create_initial_state(model::SoilModel, ic::SoilIC, zc)
+    Y_hydrology = ic.hydrology.(zc, Ref(model))
+    Y_energy = ic.energy.(zc, Ref(model))
+    return ArrayPartition(Y_hydrology, Y_energy)
+end

--- a/src/SoilModel/models.jl
+++ b/src/SoilModel/models.jl
@@ -1,0 +1,106 @@
+export SoilHydrologyModel,
+    SoilModel,
+    PrescribedTemperatureModel,
+    PrescribedHydrologyModel,
+    SoilEnergyModel
+
+abstract type AbstractSoilModel end
+"""
+    SoilEnergyModel
+The model type to be used when the user wants to simulate
+heat transfer in soil by solving the heat partial differential equation.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SoilEnergyModel <: AbstractSoilModel
+end
+
+"""
+    SoilHydrologyModel
+
+The model type to be used when the user wants to simulate
+the flow of water in soil by solving Richards equation.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SoilHydrologyModel <: AbstractSoilModel
+end
+
+"""
+    Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilModel
+        "Profile of (z,t) for temperature"
+         T_profile::Function = (z,t) -> eltype(z)(288)
+    end
+The model type to be used when the user does not wish to solve
+the heat partial differential equation, but instead wishes to prescibe
+a temperature profile in the soil.
+
+This is useful for situations where Richards Equation alone is sufficient.
+Because the hydraulic conductivity can be a function of temperature, a
+temperature profile can be supplied in order to simulate that.
+The default is 288K across the domain, the reference temperature for the viscosity effect.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilModel
+    "Profile of (z,t) for temperature"
+    T_profile::Function = (z,t) -> eltype(z)(288)
+end
+
+
+
+"""
+    Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilModel
+        "Profile of (z,t) for ϑ_l"
+        ϑ_l_profile::Function = (z,t) -> eltype(z)(0.0)
+        "Profile of (z,t) for θ_i"
+        θ_i_profile::::Function = (z,t) -> eltype(z)(0.0)
+    end
+The model type to be used when the user does not wish to solve
+the Richards equation, but instead wishes to prescibe
+a water content profile in the soil.
+
+This is useful for situations where only the heat equation is to be solved.
+Because the thermal conductivity and heat capacities depend on water content,
+a water profile must be defined to solve the heat equation.
+The default for both ice
+and liquid water content is zero, which applies for totally dry soil. 
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilModel
+    "Profile of (z,t) for ϑ_l"
+    ϑ_l_profile::Function = (z,t) -> eltype(z)(0.0)
+    "Profile of (z,t) for θ_i"
+    θ_i_profile::Function = (z,t) -> eltype(z)(0.0)
+end
+
+
+
+"""
+    SoilModel{em <: AbstractSoilModel, hm <: AbstractSoilModel, bc, A,B}
+
+The model type for the soil model.
+
+# Fields
+$(DocStringExtensions.FIELDS)
+"""
+struct SoilModel{em <: AbstractSoilModel, hm <: AbstractSoilModel, bc, A, B} <:
+       AbstractSoilModel
+    "Soil energy model - prescribed or dynamics"
+    energy_model::em
+    "Soil hydrology model - prescribed or dynamic"
+    hydrology_model::hm
+    "Boundary conditions tuple"
+    boundary_conditions::bc
+    "Soil parameters"
+    soil_param_set::A
+    "Earth parameter set"
+    earth_param_set::B
+end
+
+include("boundary_conditions.jl")
+include("right_hand_side.jl")

--- a/src/SoilModel/parameters.jl
+++ b/src/SoilModel/parameters.jl
@@ -1,0 +1,25 @@
+export SoilParams
+
+abstract type ParameterStructure{FT <: AbstractFloat} end
+
+struct SoilParams{FT} <: ParameterStructure{FT}
+    ν::FT
+    vgn::FT
+    vgα::FT
+    vgm::FT
+    ksat::FT
+    θr::FT
+    S_s::FT
+    ν_ss_gravel::FT
+    ν_ss_om::FT
+    ν_ss_quartz::FT
+    ρc_ds::FT
+    κ_solid::FT
+    ρp::FT
+    κ_sat_unfrozen::FT
+    κ_sat_frozen::FT
+    a::FT
+    b::FT
+    κ_dry_parameter::FT
+end
+

--- a/src/SoilModel/right_hand_side.jl
+++ b/src/SoilModel/right_hand_side.jl
@@ -1,0 +1,225 @@
+export make_rhs
+
+function make_rhs(model::SoilModel)
+    rhs_soil! = make_rhs!(model.energy_model, model.hydrology_model, model)
+    function rhs!( dY, Y, p, t)
+        rhs_soil!(dY,Y,p,t) 
+        return dY
+    end
+    return rhs!
+end
+
+function make_rhs!(energy::PrescribedTemperatureModel, hydrology::PrescribedHydrologyModel, model)
+    function rhs!(dY, Y, _, t)
+        (Y_hydro, Y_energy) = Y.x
+        @unpack ϑ_l, θ_i = Y_hydro
+        @unpack ρe_int = Y_energy
+        (dY_hydro, dY_energy) = dY.x
+        dρe_int = dY_energy.ρe_int
+        dϑ_l = dY_hydro.ϑ_l
+        dθ_i = dY_hydro.θ_i
+
+        #update the state Y with prescribed values at the current time
+        ϑ_l = hydrology.ϑ_l_profile.(zc, t)
+        θ_i = hydrology.θ_i_profile.(zc, t)
+        θ_l = ϑ_l # eventually have a conversion to liquid water content
+        T = energy.T_profile.(zc, t)
+        ρc_s = volumetric_heat_capacity.(θ_l, θ_i, model.soil_param_set.ρc_ds, Ref(model.earth_param_set))
+        ρe_int = volumetric_internal_energy.(θ_i, ρc_s, T, Ref(model.earth_param_set))
+        
+        # RHS is zero
+
+        cs = axes(θ_i)
+        zc = Fields.coordinate_field(cs)
+        dϑ_l = Fields.zeros(typeof(θ_i),cs)
+        dθ_i = Fields.zeros(typeof(θ_i),cs)
+        dρe_int = Fields.zeros(typeof(ρe_int),cs)
+        return dY
+    end
+    return rhs!
+end
+
+# Richards equation with temperature dependent hydraulic conductivity (optional)
+function make_rhs!(energy::PrescribedTemperatureModel, hydrology::SoilHydrologyModel, model)
+    function rhs!(dY, Y, _, t)
+        (dY_hydro, dY_energy) = dY.x
+        dϑ_l = dY_hydro.ϑ_l
+        dθ_i = dY_hydro.θ_i
+        dρe_int = dY_energy.ρe_int
+
+        (Y_hydro, Y_energy) = Y.x
+        @unpack ϑ_l, θ_i = Y_hydro
+        @unpack ρe_int = Y_energy
+
+        # boundary conditions and parameters
+        bc = model.boundary_conditions
+        top_water_flux, btm_water_flux = compute_vertical_flux(bc.top.hydrology), compute_vertical_flux(bc.bottom.hydrology)
+        sp = model.soil_param_set
+        param_set= model.earth_param_set
+        @unpack ν, vgn, vgα, vgm, ksat, θr, S_s, ρc_ds = sp
+        
+        # Evaluate T at the current time, update ρe_int
+        cs = axes(θ_i)
+        zc = Fields.coordinate_field(cs)
+        θ_l = ϑ_l
+        T = energy.T_profile.(zc, t)
+        ρc_s = volumetric_heat_capacity.(θ_l, θ_i, model.soil_param_set.ρc_ds, Ref(model.earth_param_set))
+        ρe_int = volumetric_internal_energy.(θ_i, ρc_s, T, Ref(model.earth_param_set))
+        dρe_int =Fields.zeros(eltype(ρe_int),cs)
+        
+        # Compute hydraulic head, conductivity
+        S = effective_saturation.(θ_l; ν = ν, θr = θr)
+        K = hydraulic_conductivity.(S; vgm = vgm, ksat = ksat)
+        ψ = pressure_head.(
+            S;
+            vgn = vgn,
+            vgα = vgα,
+            vgm = vgm,
+            ν = ν,
+            θr = θr,
+            S_s = S_s,
+        )
+
+        h = ψ .+ zc
+
+        # right hand side operators
+        interpc2f = Operators.InterpolateC2F()
+        gradc2f_water = Operators.GradientC2F()
+        divf2c_water = Operators.DivergenceF2C(
+            top = Operators.SetValue(top_water_flux),
+            bottom = Operators.SetValue(btm_water_flux),
+        )
+        
+        @. dϑ_l = -(divf2c_water(-interpc2f(K) * gradc2f_water(h))) #Richards equation
+        dθ_i = Fields.zeros(eltype(θ_i),cs)
+        return dY
+    end
+    return rhs!
+end
+
+# Simple heat equation in soil. Water profile is prescribed. No heat flux due to diffusion of water.
+function make_rhs!(energy::SoilEnergyModel, hydrology::PrescribedHydrologyModel, model::SoilModel)
+    function rhs!(dY, Y, _, t)
+        (dY_hydro, dY_energy) = dY.x
+        dρe_int = dY_energy.ρe_int
+        dϑ_l = dY_hydro.ϑ_l
+        dθ_i = dY_hydro.θ_i
+        (Y_hydro, Y_energy) = Y.x
+        @unpack ϑ_l, θ_i = Y_hydro
+        @unpack ρe_int = Y_energy
+
+        # boundary conditions and parameters
+        bc = model.boundary_conditions
+        top_heat_flux, btm_heat_flux = compute_vertical_flux(bc.top.energy), compute_vertical_flux(bc.bottom.energy)
+        sp = model.soil_param_set
+        param_set= model.earth_param_set
+        @unpack ν, ρc_ds, κ_sat_unfrozen, κ_sat_frozen = sp
+
+        # update water content based on prescribed profiles, set RHS to zero.
+        cs = axes(ρe_int)
+        zc = Fields.coordinate_field(cs)
+        ϑ_l = hydrology.ϑ_l_profile.(zc, t)
+        θ_i = hydrology.θ_i_profile.(zc, t)
+        dϑ_l = Fields.zeros(typeof(θ_i),cs)
+        dθ_i = Fields.zeros(typeof(θ_i),cs)
+
+        # Compute center values of everything
+        ρc_s = volumetric_heat_capacity.(θ_l, θ_i, ρc_ds, Ref(param_set))
+        T = temperature_from_ρe_int.(ρe_int, θ_i, ρc_s, Ref(param_set))
+        κ_dry = k_dry(param_set, sp)
+        S_r = relative_saturation.(θ_l, θ_i, ν)
+        kersten = kersten_number.(θ_i, S_r, Ref(sp))
+        κ_sat =
+            saturated_thermal_conductivity.(θ_l, θ_i, κ_sat_unfrozen, κ_sat_frozen)
+        κ = thermal_conductivity.(κ_dry, kersten, κ_sat)
+
+        # rhs operators
+        interpc2f = Operators.InterpolateC2F()
+        gradc2f_heat = Operators.GradientC2F()
+        divf2c_heat = Operators.DivergenceF2C(
+            top = Operators.SetValue(top_heat_flux),
+            bottom = Operators.SetValue(btm_heat_flux),
+        )
+        @. dρe_int =
+            -divf2c_heat(
+                -interpc2f(κ) * gradc2f_heat(T))
+        return dY
+    end
+    return rhs!
+end
+
+# Full model without phase changes
+
+function make_rhs!(energy::SoilEnergyModel, hydrology::SoilHydrologyModel, model::SoilModel)
+    function rhs!(dY, Y, _, t)
+        (dY_hydro, dY_energy) = dY.x
+        dρe_int = dY_energy.ρe_int
+        dϑ_l = dY_hydro.ϑ_l
+        dθ_i = dY_hydro.θ_i
+        (Y_hydro, Y_energy) = Y.x
+        @unpack ϑ_l, θ_i = Y_hydro
+        @unpack ρe_int = Y_energy
+
+        # boundary conditions and parameters
+        bc = model.boundary_conditions
+        top_water_flux, btm_water_flux = compute_vertical_flux(bc.top.hydrology), compute_vertical_flux(bc.bottom.hydrology)
+        top_heat_flux, btm_heat_flux = compute_vertical_flux(bc.top.energy), compute_vertical_flux(bc.bottom.energy)
+
+        sp = model.soil_param_set
+        param_set= model.earth_param_set
+        @unpack ν, vgn, vgα, vgm, ksat, θr, S_s, ρc_ds, κ_sat_unfrozen, κ_sat_frozen = sp
+        
+        # Compute center values of everything
+        θ_l = ϑ_l
+        ρc_s = volumetric_heat_capacity.(θ_l, θ_i, ρc_ds, Ref(param_set))
+        T = temperature_from_ρe_int.(ρe_int, θ_i, ρc_s, Ref(param_set))
+        κ_dry = k_dry(param_set, sp)
+        S_r = relative_saturation.(θ_l, θ_i, ν)
+        kersten = kersten_number.(θ_i, S_r, Ref(sp))
+        κ_sat =
+            saturated_thermal_conductivity.(θ_l, θ_i, κ_sat_unfrozen, κ_sat_frozen)
+        κ = thermal_conductivity.(κ_dry, kersten, κ_sat)
+        ρe_int_l = volumetric_internal_energy_liq.(T, Ref(param_set))
+        
+        cs = axes(θ_i)
+        zc = Fields.coordinate_field(cs)
+        
+        S = effective_saturation.(θ_l; ν = ν, θr = θr)
+        K = hydraulic_conductivity.(S; vgm = vgm, ksat = ksat)
+        ψ = pressure_head.(
+            S;
+            vgn = vgn,
+            vgα = vgα,
+            vgm = vgm,
+            ν = ν,
+            θr = θr,
+            S_s = S_s,
+        )
+        h = ψ .+ zc
+
+        # rhs operators
+        interpc2f = Operators.InterpolateC2F()
+        gradc2f_heat = Operators.GradientC2F()
+        divf2c_heat = Operators.DivergenceF2C(
+            top = Operators.SetValue(top_heat_flux),
+            bottom = Operators.SetValue(btm_heat_flux),
+        )
+        
+        gradc2f_water = Operators.GradientC2F()
+        divf2c_water = Operators.DivergenceF2C(
+            top = Operators.SetValue(top_water_flux),
+            bottom = Operators.SetValue(btm_water_flux),
+        )
+        
+        @. dϑ_l = -divf2c_water(-interpc2f(K) * gradc2f_water(h)) #Richards equation
+        dθ_i = Fields.zeros(eltype(θ_i), cs) # zero unless we add phase change        
+
+        @. dρe_int =
+            -divf2c_heat(
+                -interpc2f(κ) * gradc2f_heat(T) -
+                interpc2f(ρe_int_l * K) * gradc2f_water(h),
+            )
+        return dY
+    end
+    return rhs!
+end

--- a/test/SoilModel/heat_analytic_unit_test.jl
+++ b/test/SoilModel/heat_analytic_unit_test.jl
@@ -3,16 +3,13 @@
 # https://ocw.mit.edu/courses/mathematics/18-303-linear-partial-differential-equations-fall-2006/lecture-notes/heateqni.pdf.
 # This assumes zero water content in the soil/Prescribed water model
 
-import ClimaCore.Geometry
 import ClimaCore:
     Fields,
     Domains,
-    Topologies,
     Meshes,
-    DataLayouts,
     Operators,
-    Geometry,
-    Spaces
+    Spaces,
+    Geometry
 
 using CLIMAParameters
 struct EarthParameterSet <: AbstractEarthParameterSet end
@@ -31,7 +28,8 @@ using OrdinaryDiffEq:
 using DelimitedFiles
 using UnPack
 using LandHydrology
-using LandHydrology.SoilHeatParameterizations
+using LandHydrology.SoilInterface: SoilParams
+using LandHydrology.SoilInterface.SoilHeatParameterizations
 using Test
 using Statistics
 
@@ -57,7 +55,7 @@ function compute_soil_heat_rhs!(
 )
     sp = p[1]
     param_set = p[2]
-    @unpack ρc_ds, κ_sat_unfrozen, κ_sat_frozen = sp
+    @unpack ν, ρc_ds, κ_sat_unfrozen, κ_sat_frozen = sp
 
     θ_l, θ_i = get_water_content(I)# this is a stand in - need to get this from the soil state vector when we have water included. dispatch on soil water type - prescribed or dynamic
     ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set) # eventualyl will be different at top and bottom...
@@ -76,93 +74,101 @@ function compute_soil_heat_rhs!(
         top = Operators.SetValue(Ttop),
         bottom = Operators.SetValue(Tbot),
     )
-    gradf2c = Operators.GradientF2C()
+    divf2c = Operators.DivergenceF2C()
 
-    return @. dI = gradf2c(κ * gradc2f(T)) # κ is just a constant here - will be center Field eventually
+    return @. dI = divf2c(κ * gradc2f(T)) # κ is just a constant here - will be center Field eventually
 
 end
-ν = 0.495
-ν_ss_gravel = 0.1
-ν_ss_om = 0.1
-ν_ss_quartz = 0.1
-ρc_ds = 0.43314518988433487
-κ_solid = 8.0
-ρp = 2700.0
-κ_sat_unfrozen = 0.57
-κ_sat_frozen = 2.29
-a = 0.24
-b = 18.1
-κ_dry_parameter = 0.053
-msp = SoilHeatParams(
-    ν,
-    ν_ss_gravel,
-    ν_ss_om,
-    ν_ss_quartz,
-    ρc_ds,
-    κ_solid,
-    ρp,
-    κ_sat_unfrozen,
-    κ_sat_frozen,
-    a,
-    b,
-    κ_dry_parameter,
-)
-
-
-t0 = FT(0)
-tf = FT(2)
-dt = FT(1e-4)
-n = 60
-
-# Specify the domain boundaries
-zmax = FT(1)
-zmin = FT(0)
-domain = Domains.IntervalDomain(zmin, zmax, x3boundary = (:bottom, :top))
-mesh = Meshes.IntervalMesh(domain, nelems = n)
-
-cs = Spaces.CenterFiniteDifferenceSpace(mesh)
-fs = Spaces.FaceFiniteDifferenceSpace(cs)
-zc = Fields.coordinate_field(cs)
-
-T0 = Fields.zeros(FT, cs)
-θ_l, θ_i = get_water_content(T0)# this is a stand in - need to get this from the soil state vector when we have water included. dispatch on soil water type - prescribed or dynamic
-ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set) # eventualyl will be different at top and bottom...
-I = volumetric_internal_energy.(θ_i, ρc_s, T0, Ref(param_set))
-
-tau = FT(1) # period (sec)
-A = FT(5) # amplitude (K)
-ω = FT(2 * pi / tau)
-topbc = TDirichlet(t -> eltype(t)(0.0))
-bottombc = TDirichlet(t -> A * cos(ω * t))
-
-p = [msp, param_set, topbc, bottombc]
-function ∑tendencies!(dI, I, p, t)
-    top = p[3]
-    bot = p[4]
-    compute_soil_heat_rhs!(dI, I, t, p, top, bot)
-end
-
+@testset "heat analytic test" begin
+    ν = 0.495
+    ν_ss_gravel = 0.1
+    ν_ss_om = 0.1
+    ν_ss_quartz = 0.1
+    ρc_ds = 0.43314518988433487
+    κ_solid = 8.0
+    ρp = 2700.0
+    κ_sat_unfrozen = 0.57
+    κ_sat_frozen = 2.29
+    a = 0.24
+    b = 18.1
+    κ_dry_parameter = 0.053
+    msp = SoilParams(
+        ν,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        ν_ss_gravel,
+        ν_ss_om,
+        ν_ss_quartz,
+        ρc_ds,
+        κ_solid,
+        ρp,
+        κ_sat_unfrozen,
+        κ_sat_frozen,
+        a,
+        b,
+        κ_dry_parameter,
+    )
+    
+    
+    t0 = FT(0)
+    tf = FT(2)
+    dt = FT(1e-4)
+    n = 60
+    
+    # Specify the domain boundaries
+    zmax = FT(1)
+    zmin = FT(0)
+    domain = Domains.IntervalDomain(zmin, zmax, x3boundary = (:bottom, :top))
+    mesh = Meshes.IntervalMesh(domain, nelems = n)
+    
+    cs = Spaces.CenterFiniteDifferenceSpace(mesh)
+    fs = Spaces.FaceFiniteDifferenceSpace(cs)
+    zc = Fields.coordinate_field(cs)
+    
+    T0 = Fields.zeros(FT, cs)
+    θ_l, θ_i = get_water_content(T0)# this is a stand in - need to get this from the soil state vector when we have water included. dispatch on soil water type - prescribed or dynamic
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set) # eventualyl will be different at top and bottom...
+    I = volumetric_internal_energy.(θ_i, ρc_s, T0, Ref(param_set))
+    
+    tau = FT(1) # period (sec)
+    A = FT(5) # amplitude (K)
+    ω = FT(2 * pi / tau)
+    topbc = TDirichlet(t -> eltype(t)(0.0))
+    bottombc = TDirichlet(t -> A * cos(ω * t))
+    
+    p = [msp, param_set, topbc, bottombc]
+    function ∑tendencies!(dI, I, p, t)
+        top = p[3]
+        bot = p[4]
+        compute_soil_heat_rhs!(dI, I, t, p, top, bot)
+    end
+    
 prob = ODEProblem(∑tendencies!, I, (t0, tf), p)
-sol = solve(
-    prob,
-    TsitPap8(),
-    dt = dt,
-    saveat = 60 * dt,
-    progress = true,
-    progress_message = (dt, u, p, t) -> t,
-);
+    sol = solve(
+        prob,
+        TsitPap8(),
+        dt = dt,
+        saveat = 60 * dt,
+        progress = true,
+        progress_message = (dt, u, p, t) -> t,
+    );
+    
+    t = sol.t
+    z = parent(zc)[:]
+    num =
+        exp.(sqrt(ω / 2) * (1 + im) * (1 .- z)) .-
+        exp.(-sqrt(ω / 2) * (1 + im) * (1 .- z))
+    denom = exp(sqrt(ω / 2) * (1 + im)) - exp.(-sqrt(ω / 2) * (1 + im))
+    analytic_soln = real(num .* A * exp(im * ω * tf) / denom)
 
-t = sol.t
-z = parent(zc)[:]
-num =
-    exp.(sqrt(ω / 2) * (1 + im) * (1 .- z)) .-
-    exp.(-sqrt(ω / 2) * (1 + im) * (1 .- z))
-denom = exp(sqrt(ω / 2) * (1 + im)) - exp.(-sqrt(ω / 2) * (1 + im))
-analytic_soln = real(num .* A * exp(im * ω * tf) / denom)
-
-Ifinal = parent(sol.u[end])[:]
-θ_l, θ_i = get_water_content(Ifinal)# this is a stand in - need to get this from the soil state vector when we have water included. dispatch on soil water type - prescribed or dynamic
-ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set)
-Tfinal = temperature_from_ρe_int.(Ifinal, θ_i, ρc_s, Ref(param_set))
-MSE = mean((analytic_soln .- Tfinal) .^ 2.0)
-@test MSE < 1e-2
+    Ifinal = parent(sol.u[end])[:]
+    θ_l, θ_i = get_water_content(Ifinal)# this is a stand in - need to get this from the soil state vector when we have water included. dispatch on soil water type - prescribed or dynamic
+    ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, param_set)
+    Tfinal = temperature_from_ρe_int.(Ifinal, θ_i, ρc_s, Ref(param_set))
+    MSE = mean((analytic_soln .- Tfinal) .^ 2.0)
+    @test MSE < 1e-2
+end

--- a/test/SoilModel/richards_equation.jl
+++ b/test/SoilModel/richards_equation.jl
@@ -1,0 +1,160 @@
+import ClimaCore:
+    Fields,
+    Domains,
+    Meshes,
+    Spaces
+
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
+const param_set = EarthParameterSet()
+
+using OrdinaryDiffEq:
+    ODEProblem,
+    solve,
+    CarpenterKennedy2N54,# does not work
+    SSPRK33
+using LandHydrology
+using LandHydrology.SoilInterface
+using LandHydrology.SoilInterface.SoilWaterParameterizations
+using LandHydrology.SoilInterface.SoilHeatParameterizations
+using Statistics
+using Test
+@testset "Variably saturated equilibrium" begin
+    FT = Float64
+
+    # General soil composition
+    ν = FT(0.495);
+    #Water specific
+    Ksat = FT(0.0443 / 3600 / 100) # m/s
+    S_s = FT(1e-3) #inverse meters
+    vg_n = FT(2.0)
+    vg_α = FT(2.6); # inverse meters
+    vg_m = FT(1) - FT(1) / vg_n
+    θ_r = FT(0)
+    
+    ρc_ds = FT(2e6)
+    #collect all params
+    msp = SoilParams{FT}(
+        ν,
+        vg_n,
+        vg_α,
+        vg_m,
+        Ksat,
+        θ_r,
+        S_s,
+        0.0,
+        0.0,
+        0.0,
+        ρc_ds,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0,
+        0.0
+    )
+    
+    
+    #Simulation and domain info
+    t0 = FT(0)
+    tf = FT(60 * 60 * 24 *36)
+    dt = FT(100)
+    n = 50
+    
+    zmax = FT(0)
+    zmin = FT(-10)
+    domain = Domains.IntervalDomain(zmin, zmax, x3boundary = (:bottom, :top))
+    mesh = Meshes.IntervalMesh(domain, nelems = n)
+    
+    cs = Spaces.CenterFiniteDifferenceSpace(mesh)
+    fs = Spaces.FaceFiniteDifferenceSpace(cs)
+    zc = Fields.coordinate_field(cs)
+    
+    #Boundary conditions
+    top_water_flux = FT(0)
+    bottom_water_flux = FT(0)
+    bc = SoilDomainBC(top = SoilComponentBC(hydrology = VerticalFlux(top_water_flux)),
+                      bottom = SoilComponentBC(hydrology = VerticalFlux(bottom_water_flux)))
+    
+    # create model
+    soil_model = SoilModel(PrescribedTemperatureModel(), SoilHydrologyModel(), bc, msp, param_set)
+    
+    # initial conditions
+    
+    function energy_ic(z, model)
+        t0 = 0.0
+        T = model.energy_model.T_profile(z,t0) # to be consistent with PrescribedT Default. 
+        θ_i = 0.0
+        θ_l = 0.494
+        ρc_ds =model.soil_param_set.ρc_ds
+        ρc_s = volumetric_heat_capacity(θ_l, θ_i, ρc_ds, model.earth_param_set)
+        ρe_int = volumetric_internal_energy(θ_i, ρc_s, T, model.earth_param_set)
+        return (;ρe_int = ρe_int,)
+    end
+    
+    
+    function hydrology_ic(z, model)
+        θ_i = 0.0
+        θ_l  = 0.494
+        return (ϑ_l = θ_l, θ_i = θ_i)
+    end
+    
+    ic = SoilIC(; hydrology = hydrology_ic, energy = energy_ic)
+    
+    Y = create_initial_state(soil_model, ic, zc)
+    soil_rhs! = make_rhs(soil_model)
+   # dY =  similar(Y)
+   # soil_rhs!(dY,Y,[],0.0)
+    prob = ODEProblem(soil_rhs!, Y, (t0, tf), [])
+    
+    # solve simulation
+    sol = solve(
+        prob,
+        #TsitPap8(), doesnt work, ArgumentError: broadcasting over dictionaries and `NamedTuple`s is reserved
+        #        CarpenterKennedy2N54(), # this does work
+        SSPRK33(),
+        dt = dt,
+        saveat = 60 * dt,
+        progress = true,
+        progress_message = (dt, u, p, t) -> t,
+);
+    
+    
+    z = parent(zc)
+    ϑ_l = [parent(sol.u[k].x[1].ϑ_l) for k in 1:length(sol.u)]
+    function expected(z, z_interface)
+        ν = 0.495
+        S_s = 1e-3
+        α = 2.6
+        n = 2.0
+        m = 0.5
+        if z < z_interface
+            return -S_s * (z - z_interface) + ν
+        else
+            return ν * (1 + (α * (z - z_interface))^n)^(-m)
+        end
+    end
+    
+    
+    
+    @test sqrt(mean(ϑ_l[end] .- expected.(z, -0.56)).^2.0) < 1e-4
+end
+#= 
+#Plotting
+indices = [1, 88, length(sol.t)]
+labels = ["IC", "6d", "36d"]
+plot1 = plot(
+    xlim = (0.4, 0.525),
+    ylim = (-10, 0),
+    legend = :outerright,
+    xlabel = "θ(z)",
+    ylabel = "z",
+)
+for i in 1:1:length(indices)
+    plot!(ϑ_l[indices[i]], z, label = labels[i], lw = 2)
+end
+
+plot!(expected.(z, -0.56), z, lw =1, label = "expected");
+plot(plot1)
+=#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,3 +1,5 @@
+include("SoilModel/richards_equation.jl")
+#Currently these tests dont use the new interface b/c dirichlet BC dont work yet.
 include("SoilModel/richards_vg.jl")
 include("SoilModel/heat_analytic_unit_test.jl")
 #include("SoilModel/dirichlet_bc_as_flux.jl")


### PR DESCRIPTION
PR adding in some structure to setting the RHS, initial conditions, and boundary conditions for the soil model.

Currently this is written such that prescribed models are still stored in the state vector.

Note that 2 of the tests do not use this interface yet, because I need to update the BC to handle dirichlet conditions to do so, but one does (hydrology only), and an experiment does (full model).

still to come: simulation structure, passing in domain info, further BC work, parameter work, having the simulation initialize the state vector to a default.

