### PR TITLE
Put domain in model

### DIFF
--- a/src/Domains/Domains.jl
+++ b/src/Domains/Domains.jl
@@ -1,0 +1,26 @@
+module Domains
+
+using ClimaCore
+using Printf
+
+import ClimaCore: Meshes, Spaces, Topologies
+
+"""
+    AbstractDomain
+"""
+abstract type AbstractDomain end
+
+"""
+    AbstractVerticalDomain
+"""
+abstract type AbstractVerticalDomain{FT} <: AbstractDomain end
+
+include("domain.jl")
+
+export AbstractDomain
+export AbstractVerticalDomain
+export Column
+export make_function_space
+
+end # module
+

--- a/src/Domains/domain.jl
+++ b/src/Domains/domain.jl
@@ -1,0 +1,45 @@
+"""
+    Column{FT} <: AbstractVerticalDomain
+"""
+struct Column{FT} <: AbstractVerticalDomain{FT}
+    zlim::Tuple{FT, FT}
+    nelements::Int32
+end
+
+function Column(FT::DataType = Float64; zlim, nelements)
+    @assert zlim[1] < zlim[2]
+    return Column{FT}(zlim, nelements)
+end
+
+Base.ndims(::Column) = 1
+
+Base.length(domain::Column) = domain.zlim[2] - domain.zlim[1]
+
+Base.size(domain::Column) = length(domain)
+
+function Base.show(io::IO, domain::Column)
+    min = domain.zlim[1]
+    max = domain.zlim[2]
+    printstyled(io, "[", color = 226)
+    astring = @sprintf("%0.1f", min)
+    bstring = @sprintf("%0.1f", max)
+    printstyled(astring, ", ", bstring, color = 7)
+    printstyled(io, "]", color = 226)
+end
+
+
+"""
+    make_function_space(domain::Column)
+"""
+function make_function_space(domain::Column{FT}) where {FT}
+    column = ClimaCore.Domains.IntervalDomain(
+        domain.zlim[1],
+        domain.zlim[2];
+        x3boundary = (:bottom, :top),
+    )
+    mesh = Meshes.IntervalMesh(column; nelems = domain.nelements)
+    center_space = Spaces.CenterFiniteDifferenceSpace(mesh)
+    face_space = Spaces.FaceFiniteDifferenceSpace(center_space)
+
+    return center_space, face_space
+end

--- a/src/LandHydrology.jl
+++ b/src/LandHydrology.jl
@@ -1,5 +1,7 @@
 module LandHydrology
 
+include("Domains/Domains.jl")
+include("Models.jl")
 include(joinpath("SoilModel", "SoilInterface.jl"))
 
 end # module

--- a/src/Models.jl
+++ b/src/Models.jl
@@ -1,0 +1,6 @@
+module Models
+export AbstractModel
+
+abstract type AbstractModel end
+
+end

--- a/src/SoilModel/SoilInterface.jl
+++ b/src/SoilModel/SoilInterface.jl
@@ -3,6 +3,8 @@ import ClimaCore:    Fields, Operators, Geometry
 using DocStringExtensions
 using UnPack
 
+using LandHydrology.Domains: AbstractVerticalDomain, make_function_space
+using LandHydrology.Models: AbstractModel
 include("SoilWaterParameterizations.jl")
 using .SoilWaterParameterizations
 include("SoilHeatParameterizations.jl")

--- a/src/SoilModel/initial_conditions.jl
+++ b/src/SoilModel/initial_conditions.jl
@@ -12,7 +12,9 @@ function SoilIC(;energy = energy, hydrology = hydrology)
     return SoilIC{typeof.(args)...}(args...)
 end
 
-function create_initial_state(model::SoilModel, ic::SoilIC, zc)
+function create_initial_state(model::SoilModel, ic::SoilIC)
+    space_c, _ = make_function_space(model.domain)
+    zc = Fields.coordinate_field(space_c)
     Y_hydrology = ic.hydrology.(zc, Ref(model))
     Y_energy = ic.energy.(zc, Ref(model))
     return ArrayPartition(Y_hydrology, Y_energy)

--- a/src/SoilModel/models.jl
+++ b/src/SoilModel/models.jl
@@ -3,8 +3,9 @@ export SoilHydrologyModel,
     PrescribedTemperatureModel,
     PrescribedHydrologyModel,
     SoilEnergyModel
+using RecursiveArrayTools: ArrayPartition
 
-abstract type AbstractSoilModel end
+abstract type AbstractSoilComponentModel end
 """
     SoilEnergyModel
 The model type to be used when the user wants to simulate
@@ -13,7 +14,7 @@ heat transfer in soil by solving the heat partial differential equation.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SoilEnergyModel <: AbstractSoilModel
+struct SoilEnergyModel <: AbstractSoilComponentModel
 end
 
 """
@@ -25,11 +26,11 @@ the flow of water in soil by solving Richards equation.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SoilHydrologyModel <: AbstractSoilModel
+struct SoilHydrologyModel <: AbstractSoilComponentModel
 end
 
 """
-    Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilModel
+    Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilComponentModel
         "Profile of (z,t) for temperature"
          T_profile::Function = (z,t) -> eltype(z)(288)
     end
@@ -45,15 +46,15 @@ The default is 288K across the domain, the reference temperature for the viscosi
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilModel
+Base.@kwdef struct PrescribedTemperatureModel <: AbstractSoilComponentModel
     "Profile of (z,t) for temperature"
-    T_profile::Function = (z,t) -> eltype(z)(288)
+    T_profile::Function = (z,t) -> eltype(t)(288)
 end
 
 
 
 """
-    Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilModel
+    Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilComponentModel
         "Profile of (z,t) for ϑ_l"
         ϑ_l_profile::Function = (z,t) -> eltype(z)(0.0)
         "Profile of (z,t) for θ_i"
@@ -71,7 +72,7 @@ and liquid water content is zero, which applies for totally dry soil.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilModel
+Base.@kwdef struct PrescribedHydrologyModel <: AbstractSoilComponentModel
     "Profile of (z,t) for ϑ_l"
     ϑ_l_profile::Function = (z,t) -> eltype(z)(0.0)
     "Profile of (z,t) for θ_i"
@@ -88,8 +89,8 @@ The model type for the soil model.
 # Fields
 $(DocStringExtensions.FIELDS)
 """
-struct SoilModel{em <: AbstractSoilModel, hm <: AbstractSoilModel, bc, A, B} <:
-       AbstractSoilModel
+struct SoilModel{FT, dm <: AbstractVerticalDomain{FT}, em <: AbstractSoilComponentModel, hm <: AbstractSoilComponentModel, bc, A, B} <: AbstractModel
+    domain::dm
     "Soil energy model - prescribed or dynamics"
     energy_model::em
     "Soil hydrology model - prescribed or dynamic"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,5 +1,5 @@
 include("SoilModel/richards_equation.jl")
+include("test_domains.jl")
 #Currently these tests dont use the new interface b/c dirichlet BC dont work yet.
 include("SoilModel/richards_vg.jl")
 include("SoilModel/heat_analytic_unit_test.jl")
-#include("SoilModel/dirichlet_bc_as_flux.jl")

--- a/test/test_domains.jl
+++ b/test/test_domains.jl
@@ -1,0 +1,37 @@
+using Test
+using LandHydrology.Domains: Column
+function instantiate_column(FT)
+    domain = Column(FT, zlim = (0.0, 1.0), nelements = 2)
+    check1 = domain.zlim == (0.0, 1.0)
+    check2 = domain.nelements == 2
+
+    return check1 && check2
+end
+float_types = (Float32, Float64)
+@testset "Domains" begin
+    @info "Testing ClimaAtmos.Domains..."
+
+    @testset "Domains" begin
+        for FT in float_types
+            @test instantiate_column(FT)
+
+            # Test ndims
+            I = Column(FT, zlim = (0.0, 1.0), nelements = 2)
+            @test ndims(I) == 1
+
+            # Test length
+            I = Column(FT, zlim = (1.0, 2.0), nelements = 2)
+            @test length(I) == 1.0
+
+            # Test size
+            I = Column(FT, zlim = (1.0, 4.0), nelements = 2)
+            @test size(I) == 3.0
+
+            # Test show functions
+            I = Column(FT, zlim = (0.0, 1.0), nelements = 2)
+            show(I)
+            println()
+            @test I isa Column{FT}
+        end
+    end
+end


### PR DESCRIPTION
Created structure around the domain - user now defines it more simply, by passing in zmin, zmax, and # of elements to a column constructor. This domain object is stored within the model, and necessary field info, etc is accessible to the RHS now via model.domain.

