### PR TITLE
removed parent calls in src code, added helper fn.

### DIFF
--- a/src/SoilModel/SoilInterface.jl
+++ b/src/SoilModel/SoilInterface.jl
@@ -1,5 +1,5 @@
 module SoilInterface
-import ClimaCore: Fields, Operators, Geometry
+import ClimaCore: Fields, Operators, Geometry, Spaces
 using DocStringExtensions
 using UnPack
 


### PR DESCRIPTION
Following Jake's advice, I tried to make it so that most calls ClimaCore in our src code, excepting to ClimaCore `Operators`, are now wrapped in helper functions:
make_function_space: https://github.com/CliMA/LandHydrology.jl/blob/e3279209dddff65a61ef8476c0826115d2413c3c/src/Domains/domain.jl#L58
get_interior_values: https://github.com/CliMA/LandHydrology.jl/blob/e3279209dddff65a61ef8476c0826115d2413c3c/src/SoilModel/boundary_conditions.jl#L118
get_boundary_cf_distance: https://github.com/CliMA/LandHydrology.jl/blob/e3279209dddff65a61ef8476c0826115d2413c3c/src/SoilModel/boundary_conditions.jl#L143
and these simple ones: https://github.com/CliMA/LandHydrology.jl/blob/e3279209dddff65a61ef8476c0826115d2413c3c/src/SoilModel/right_hand_side.jl#L9, https://github.com/CliMA/LandHydrology.jl/blob/3dcc75773fa296be2f867ac2b12a6280d17d16cf/src/SoilModel/right_hand_side.jl#L18

I also removed the examples of "parent" of all code in src, but have not removed it from integration tests yet.