### PR TITLE
move params struct out of LandHydrology.jl

### DIFF
--- a/src/LandHydrology.jl
+++ b/src/LandHydrology.jl
@@ -1,6 +1,4 @@
 module LandHydrology
-using CLIMAParameters
-struct EarthParameterSet <: AbstractEarthParameterSet end
 
 include("Domains/Domains.jl")
 include("Models.jl")

--- a/src/SoilModel/SoilInterface.jl
+++ b/src/SoilModel/SoilInterface.jl
@@ -6,7 +6,6 @@ using CLIMAParameters.Planet: T_0
 using DocStringExtensions
 using UnPack
 
-using LandHydrology: EarthParameterSet
 using LandHydrology.Domains: AbstractVerticalDomain, make_function_space, Column
 using LandHydrology.Models: AbstractModel
 import LandHydrology: Models

--- a/src/SoilModel/models.jl
+++ b/src/SoilModel/models.jl
@@ -110,9 +110,9 @@ function SoilModel(
     hydrology_model::AbstractSoilComponentModel,
     boundary_conditions::BC,
     soil_param_set::SoilParams{FT} = SoilParams{FT}(),
-    earth_param_set::EarthParameterSet = EarthParameterSet(),
+    earth_param_set::ep,
     name::Symbol = :soil,
-) where {FT, BC}
+) where {FT, BC, ep}
     args = (
         domain,
         energy_model,

--- a/test/SoilModel/test_rhs.jl
+++ b/test/SoilModel/test_rhs.jl
@@ -18,6 +18,7 @@
             θ_i_profile = θ_ip,
         ),
         boundary_conditions = nothing,
+        earth_param_set = nothing,
     )
     Ys = Dict()
     Y = Fields.FieldVector(; Ys...)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -10,7 +10,8 @@ using OrdinaryDiffEq:
     SSPRK73
 using LandHydrology
 using LandHydrology.Models: default_initial_conditions
-using LandHydrology: EarthParameterSet
+using CLIMAParameters
+struct EarthParameterSet <: AbstractEarthParameterSet end
 const param_set = EarthParameterSet()
 using LandHydrology.Domains: Column, make_function_space
 using LandHydrology.SoilInterface


### PR DESCRIPTION
Moving EarthParameterSet definition outside of the LandHydrology.jl module. As per @charleskawczynski, this has to be defined at the driver script level to avoid conflicts between parameter sets internally.