### PR TITLE
Ignore GitHub CodeCov annotations

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+comment: false
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        # this allows a 10% drop from the previous base commit coverage
+        threshold: 10%
+
+github_checks:
+    annotations: false


### PR DESCRIPTION
I find that the GitHub codecov annotations can make reviewing a bit of a pain. They can be easily hidden (on desktop) by pressing the `A` key. This PR turns the GH coverage annotations off.